### PR TITLE
refactor: manage cart focus with refs

### DIFF
--- a/frontend/src/components/ProductCard.jsx
+++ b/frontend/src/components/ProductCard.jsx
@@ -1,5 +1,6 @@
 import { useCart } from '../store/cart.jsx'
 import { motion } from 'framer-motion'
+import { useRef } from 'react'
 import CardSpotlight from './ui/CardSpotlight.jsx'
 import ButtonAnimatedGradient from './ui/ButtonAnimatedGradient.jsx'
 import QuantityStepper from './ui/QuantityStepper.jsx'
@@ -10,6 +11,16 @@ export default function ProductCard({ product }) {
   const item = items?.find?.(it => it.product.id === product.id)
   const qty = item?.quantity ?? 0
   const inCart = qty > 0
+  const inputRef = useRef(null)
+
+  const updateQty = (newQty) => {
+    if ((newQty ?? 0) <= 0) {
+      inputRef.current?.blur?.()
+      remove(product.id)
+    } else {
+      setQty(product.id, newQty)
+    }
+  }
   return (
     <motion.div initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.25 }}>
       <CardSpotlight
@@ -52,16 +63,11 @@ export default function ProductCard({ product }) {
           ) : inCart ? (
             <div className="w-full flex justify-center">
               <QuantityStepper
+                ref={inputRef}
                 value={qty}
-                onDecrement={() => {
-                  if ((qty ?? 0) <= 1) { try { document.activeElement?.blur?.() } catch {} ; remove(product.id) }
-                  else setQty(product.id, qty - 1)
-                }}
+                onDecrement={() => updateQty(qty - 1)}
                 onIncrement={() => add(product, 1)}
-                onSet={(v) => {
-                  if ((v ?? 0) <= 0) { try { document.activeElement?.blur?.() } catch {} ; remove(product.id) }
-                  else setQty(product.id, v)
-                }}
+                onSet={updateQty}
                 className="w-3/5 mx-auto h-12"
               />
             </div>

--- a/frontend/src/components/ui/QuantityStepper.jsx
+++ b/frontend/src/components/ui/QuantityStepper.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, forwardRef } from 'react'
 
-export default function QuantityStepper({ value = 1, onDecrement, onIncrement, onSet, className = '' }) {
+function QuantityStepper({ value = 1, onDecrement, onIncrement, onSet, className = '' }, ref) {
   const [inner, setInner] = useState(String(value))
   useEffect(() => { setInner(String(value)) }, [value])
 
@@ -23,6 +23,7 @@ export default function QuantityStepper({ value = 1, onDecrement, onIncrement, o
         −
       </button>
       <input
+        ref={ref}
         type="number"
         inputMode="numeric"
         pattern="[0-9]*"
@@ -54,3 +55,5 @@ export default function QuantityStepper({ value = 1, onDecrement, onIncrement, o
     </div>
   )
 }
+
+export default forwardRef(QuantityStepper)


### PR DESCRIPTION
## Summary
- Replace global `document.activeElement.blur` calls with a stepper input ref
- Centralize cart quantity change logic for decrement and manual set

## Testing
- `npm test` *(fails: Missing script)*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_68bf77730abc8330b9e54e41f3c2d096