### PR TITLE
Require explicit Django secrets and hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
-DJANGO_SECRET_KEY=please-change-this
+# Copiar como `.env` y completar con valores reales
+DJANGO_SECRET_KEY=
 DJANGO_DEBUG=False
-DJANGO_ALLOWED_HOSTS=*
+# Lista de hosts permitidos separados por coma, sin comodines
+DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 DJANGO_RUN_SEED=False
+
 VITE_API_URL=/api
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ Requisitos:
 - Python 3.10+
 - Node 18+
 
+Configuración inicial:
+
+1. Copiar `.env.example` a `.env` y definir una clave secreta y los hosts permitidos.
+   - Para generar una `SECRET_KEY` segura:
+
+     ```bash
+     python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
+     ```
+   - Colocar el valor generado en `DJANGO_SECRET_KEY`.
+   - Configurar `DJANGO_ALLOWED_HOSTS` con una lista de dominios o IPs separados por coma (sin comodines).
+
 Backend (Django + DRF)
 
 1) Instalar dependencias:

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -3,13 +3,19 @@ import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'dev-secret-key-change-me')
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    raise ValueError("DJANGO_SECRET_KEY must be set")
 
-# Read DEBUG from env (default False for deploy)
-DEBUG = os.environ.get('DJANGO_DEBUG', 'True').lower() in ('1', 'true', 'yes')
+# Read DEBUG from env (default False)
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('1', 'true', 'yes')
 
-# Allow overriding hosts via env, default to '*'
-ALLOWED_HOSTS = [h.strip() for h in os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(',') if h.strip()]
+raw_hosts = os.environ.get('DJANGO_ALLOWED_HOSTS')
+if not raw_hosts:
+    raise ValueError("DJANGO_ALLOWED_HOSTS must be set")
+ALLOWED_HOSTS = [h.strip() for h in raw_hosts.split(',') if h.strip()]
+if '*' in ALLOWED_HOSTS:
+    raise ValueError("DJANGO_ALLOWED_HOSTS cannot contain '*'")
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     environment:
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-change-me}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:?DJANGO_SECRET_KEY is required}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
-      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:?DJANGO_ALLOWED_HOSTS is required}
       DJANGO_RUN_SEED: ${DJANGO_RUN_SEED:-False}
     volumes:
       - media:/app/media


### PR DESCRIPTION
## Summary
- Require DJANGO_SECRET_KEY and explicit DJANGO_ALLOWED_HOSTS in docker-compose and settings
- Default DEBUG to False and reject wildcard hosts
- Document generating a SECRET_KEY and configuring allowed hosts

## Testing
- `DJANGO_SECRET_KEY=dummy DJANGO_ALLOWED_HOSTS=localhost python manage.py check`
- `DJANGO_SECRET_KEY=dummy DJANGO_ALLOWED_HOSTS=localhost python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7ac8a4c08330896d671a59f9a415