### PR TITLE
Require auth for orders and support token credentials

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -4,6 +4,7 @@ from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from django.db import models
+from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from .models import Category, Product, SiteConfig, Order, Coupon, Announcement
 from .serializers import (
@@ -19,6 +20,7 @@ from .serializers import (
 class CategoryViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
+    permission_classes = [AllowAny]
 
 
 class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
@@ -27,9 +29,11 @@ class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.
     filter_backends = [DjangoFilterBackend, SearchFilter]
     filterset_fields = ['category', 'promoted']
     search_fields = ['name', 'description']
+    permission_classes = [AllowAny]
 
 
 class SiteConfigViewSet(viewsets.ViewSet):
+    permission_classes = [AllowAny]
     def list(self, request):
         cfg = SiteConfig.objects.first()
         if cfg:
@@ -47,9 +51,12 @@ class SiteConfigViewSet(viewsets.ViewSet):
 class OrderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
+    permission_classes = [IsAuthenticated]
 
 
 class CouponValidateView(APIView):
+    permission_classes = [AllowAny]
+
     def get(self, request):
         code = request.query_params.get('code', '').strip()
         if not code:
@@ -67,6 +74,7 @@ class AnnouncementViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = AnnouncementSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = []
+    permission_classes = [AllowAny]
 
     def get_queryset(self):
         from django.utils import timezone

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 
     'rest_framework',
+    'rest_framework.authtoken',
     'corsheaders',
     'django_filters',
 
@@ -86,9 +87,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 DEFAULT_CHARSET = 'utf-8'
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [],  # Endpoints públicos para el MVP
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.TokenAuthentication',
+    ],
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.AllowAny',
+        'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ],
     'DEFAULT_FILTER_BACKENDS': [
         'django_filters.rest_framework.DjangoFilterBackend',
@@ -101,4 +105,4 @@ CORS_ALLOWED_ORIGINS = [
     'http://localhost:5173',
     'http://127.0.0.1:5173',
 ]
-CORS_ALLOW_CREDENTIALS = False
+CORS_ALLOW_CREDENTIALS = True

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,14 @@
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api'
 
+function authFetch(url, options = {}) {
+  const token = localStorage.getItem('authToken')
+  const headers = { ...(options.headers || {}) }
+  if (token) headers['Authorization'] = `Token ${token}`
+  return fetch(url, { credentials: 'include', ...options, headers })
+}
+
 export async function getCategories() {
-  const r = await fetch(`${API_URL}/categories/`)
+  const r = await authFetch(`${API_URL}/categories/`)
   if (!r.ok) throw new Error('Error al cargar categorías')
   return r.json()
 }
@@ -11,19 +18,19 @@ export async function getProducts(params = {}) {
   Object.entries(params).forEach(([k, v]) => {
     if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v)
   })
-  const r = await fetch(url)
+  const r = await authFetch(url)
   if (!r.ok) throw new Error('Error al cargar productos')
   return r.json()
 }
 
 export async function getSiteConfig() {
-  const r = await fetch(`${API_URL}/config/`)
+  const r = await authFetch(`${API_URL}/config/`)
   if (!r.ok) throw new Error('Error al cargar configuración')
   return r.json()
 }
 
 export async function createOrder(payload) {
-  const r = await fetch(`${API_URL}/orders/`, {
+  const r = await authFetch(`${API_URL}/orders/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
@@ -39,13 +46,13 @@ export async function createOrder(payload) {
 export async function validateCoupon(code) {
   const url = new URL(`${API_URL}/coupons/validate/`)
   url.searchParams.set('code', code)
-  const r = await fetch(url)
+  const r = await authFetch(url)
   if (!r.ok) throw new Error('No se pudo validar el cupón')
   return r.json()
 }
 
 export async function getAnnouncements() {
-  const r = await fetch(`${API_URL}/announcements/`)
+  const r = await authFetch(`${API_URL}/announcements/`)
   if (!r.ok) throw new Error('Error al cargar anuncios')
   return r.json()
 }


### PR DESCRIPTION
## Summary
- configure DRF with session and token authentication and IsAuthenticatedOrReadOnly permissions
- restrict order creation to authenticated users and allow anonymous access to read-only endpoints
- send auth tokens and cookies with frontend API requests

## Testing
- `python manage.py test`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7acf39448330a9ce89c722a9b5d8