### PR TITLE
Add HTTPS security settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ Flujo de uso del MVP
 - Carrito: se persiste en localStorage.
 - Checkout: completar datos y método de pago; al confirmar se crea el pedido en /api/orders/ y se abre WhatsApp con un mensaje prellenado con el detalle.
 
+## Seguridad y HTTPS
+
+Para entornos de producción, el archivo `backend/supermercado/settings.py` permite ajustar opciones de seguridad mediante variables de entorno:
+
+- `DJANGO_SECURE_SSL_REDIRECT`: redirige tráfico HTTP a HTTPS.
+- `DJANGO_SECURE_HSTS_SECONDS`: segundos para HSTS (ej. `31536000`).
+- `DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS` y `DJANGO_SECURE_HSTS_PRELOAD`: activar en despliegues HTTPS.
+- `DJANGO_SESSION_COOKIE_SECURE` y `DJANGO_CSRF_COOKIE_SECURE`: marcan cookies como seguras.
+- `DJANGO_X_FRAME_OPTIONS`: política de `X-Frame-Options` (`DENY` por defecto).
+- `DJANGO_SECURE_CONTENT_TYPE_NOSNIFF`: evita inferencia de tipos de contenido.
+- `DJANGO_SECURE_REFERRER_POLICY`: política de referrer (`same-origin` por defecto).
+
+Ajustar estos valores según el entorno (desarrollo o producción) para reforzar la seguridad.

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -102,3 +102,28 @@ CORS_ALLOWED_ORIGINS = [
     'http://127.0.0.1:5173',
 ]
 CORS_ALLOW_CREDENTIALS = False
+
+# Security settings (tune via environment variables)
+SECURE_SSL_REDIRECT = os.environ.get('DJANGO_SECURE_SSL_REDIRECT', 'False').lower() in ('1', 'true', 'yes')
+
+SECURE_HSTS_SECONDS = int(os.environ.get('DJANGO_SECURE_HSTS_SECONDS', '0'))
+SECURE_HSTS_INCLUDE_SUBDOMAINS = os.environ.get('DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS', 'False').lower() in (
+    '1', 'true', 'yes'
+)
+SECURE_HSTS_PRELOAD = os.environ.get('DJANGO_SECURE_HSTS_PRELOAD', 'False').lower() in (
+    '1', 'true', 'yes'
+)
+
+SESSION_COOKIE_SECURE = os.environ.get('DJANGO_SESSION_COOKIE_SECURE', 'False').lower() in (
+    '1', 'true', 'yes'
+)
+CSRF_COOKIE_SECURE = os.environ.get('DJANGO_CSRF_COOKIE_SECURE', 'False').lower() in (
+    '1', 'true', 'yes'
+)
+
+X_FRAME_OPTIONS = os.environ.get('DJANGO_X_FRAME_OPTIONS', 'DENY')
+
+SECURE_CONTENT_TYPE_NOSNIFF = os.environ.get('DJANGO_SECURE_CONTENT_TYPE_NOSNIFF', 'True').lower() in (
+    '1', 'true', 'yes'
+)
+SECURE_REFERRER_POLICY = os.environ.get('DJANGO_SECURE_REFERRER_POLICY', 'same-origin')


### PR DESCRIPTION
## Summary
- Configure Django security options (SSL redirect, HSTS, secure cookies, X-Frame, etc.) via environment variables
- Document how to enable and adjust these settings for different environments

## Testing
- `python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7d4d2dfc8330b43d8202e3a8cd11