### PR TITLE
Add security headers and caching to Nginx config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,6 +2,20 @@ server {
     listen 80;
     server_name _;
 
+    # Security headers
+    add_header Content-Security-Policy "default-src 'self';" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    # Compression
+    gzip on;
+    gzip_types text/css application/javascript application/json text/plain text/xml image/svg+xml;
+
+    # Enable ETag headers
+    etag on;
+
     # Frontend build output
     root /usr/share/nginx/html;
     index index.html;
@@ -29,6 +43,7 @@ server {
         alias /static/;
         access_log off;
         expires 1h;
+        add_header Cache-Control "public, max-age=3600, immutable" always;
     }
 
     # Django media files (uploads)
@@ -36,6 +51,7 @@ server {
         alias /media/;
         access_log off;
         expires 1h;
+        add_header Cache-Control "public, max-age=3600" always;
     }
 
     # SPA fallback


### PR DESCRIPTION
## Summary
- add security headers to frontend Nginx config
- enable gzip compression
- configure caching for static and media files

## Testing
- `npm test` (fails: Missing script "test")
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bf7d4d61f48330ae4999ccdde723c8