### PR TITLE
Secure coupon validation endpoint

### DIFF
--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -94,6 +94,9 @@ REST_FRAMEWORK = {
         'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.SearchFilter',
     ],
+    'DEFAULT_THROTTLE_RATES': {
+        'coupon_validate': '5/min',
+    },
 }
 
 # CORS para desarrollo


### PR DESCRIPTION
## Summary
- Validate coupons via POST requests with generic invalid responses
- Add scoped rate throttling for coupon validation endpoint
- Configure throttle rate for coupon validation in settings

## Testing
- `python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7d4da6f483308eb36869fb125cbe