### PR TITLE
Add request throttling and tests for sensitive endpoints

### DIFF
--- a/backend/shop/tests/test_throttling.py
+++ b/backend/shop/tests/test_throttling.py
@@ -1,0 +1,40 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from shop.models import Category, Product
+
+
+class OrderThrottleTests(APITestCase):
+    def setUp(self):
+        cat = Category.objects.create(name='cat', slug='cat')
+        self.product = Product.objects.create(
+            category=cat, name='prod', price=10, stock=10
+        )
+        self.url = reverse('order-list')
+
+    def _payload(self):
+        return {
+            'name': 'John',
+            'phone': '123',
+            'address': '',
+            'notes': '',
+            'payment_method': 'cash',
+            'delivery_method': 'delivery',
+            'items': [{'product_id': self.product.id, 'quantity': 1}],
+        }
+
+    def test_order_throttle(self):
+        for _ in range(3):
+            resp = self.client.post(self.url, self._payload(), format='json')
+            self.assertNotEqual(resp.status_code, 429)
+        resp = self.client.post(self.url, self._payload(), format='json')
+        self.assertEqual(resp.status_code, 429)
+
+
+class CouponThrottleTests(APITestCase):
+    def test_coupon_throttle(self):
+        url = reverse('coupon-validate')
+        for _ in range(2):
+            resp = self.client.get(url, {'code': 'TEST'})
+            self.assertNotEqual(resp.status_code, 429)
+        resp = self.client.get(url, {'code': 'TEST'})
+        self.assertEqual(resp.status_code, 429)

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
+from rest_framework.throttling import ScopedRateThrottle
 from django.db import models
 
 from .models import Category, Product, SiteConfig, Order, Coupon, Announcement
@@ -47,9 +48,13 @@ class SiteConfigViewSet(viewsets.ViewSet):
 class OrderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'orders'
 
 
 class CouponValidateView(APIView):
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'coupon-validate'
     def get(self, request):
         code = request.query_params.get('code', '').strip()
         if not code:

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -94,6 +94,13 @@ REST_FRAMEWORK = {
         'django_filters.rest_framework.DjangoFilterBackend',
         'rest_framework.filters.SearchFilter',
     ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.ScopedRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'orders': '3/minute',
+        'coupon-validate': '2/minute',
+    },
 }
 
 # CORS para desarrollo


### PR DESCRIPTION
## Summary
- Configure default ScopedRateThrottle and per-scope limits in REST framework settings
- Apply strict throttling to order creation and coupon validation views
- Add tests asserting 429 Too Many Requests when limits are exceeded

## Testing
- `cd backend && python manage.py test && cd ..`


------
https://chatgpt.com/codex/tasks/task_e_68bf7d53c1488330870481e09104dd06