### PR TITLE
Implement server-side product pagination and search

### DIFF
--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -2,7 +2,8 @@ from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.filters import SearchFilter
+from rest_framework.filters import SearchFilter, OrderingFilter
+from rest_framework.pagination import PageNumberPagination
 from django.db import models
 
 from .models import Category, Product, SiteConfig, Order, Coupon, Announcement
@@ -21,12 +22,18 @@ class CategoryViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets
     serializer_class = CategorySerializer
 
 
+class ProductPagination(PageNumberPagination):
+    page_size = 12
+
+
 class ProductViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     queryset = Product.objects.filter(is_active=True).select_related('category')
     serializer_class = ProductSerializer
-    filter_backends = [DjangoFilterBackend, SearchFilter]
+    filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ['category', 'promoted']
     search_fields = ['name', 'description']
+    ordering_fields = ['name', 'price', 'offer_price', 'created_at']
+    pagination_class = ProductPagination
 
 
 class SiteConfigViewSet(viewsets.ViewSet):

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -6,11 +6,13 @@ export async function getCategories() {
   return r.json()
 }
 
-export async function getProducts(params = {}) {
+export async function getProducts({ page = 1, search = '', ordering = '', category, page_size } = {}) {
   const url = new URL(`${API_URL}/products/`)
-  Object.entries(params).forEach(([k, v]) => {
-    if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v)
-  })
+  if (page) url.searchParams.set('page', page)
+  if (search) url.searchParams.set('search', search)
+  if (ordering) url.searchParams.set('ordering', ordering)
+  if (category) url.searchParams.set('category', category)
+  if (page_size) url.searchParams.set('page_size', page_size)
   const r = await fetch(url)
   if (!r.ok) throw new Error('Error al cargar productos')
   return r.json()


### PR DESCRIPTION
## Summary
- add PageNumberPagination and ordering support to product API
- allow frontend to request product pages with search and sort parameters
- wire up Home page to server-side pagination and display navigation controls

## Testing
- `python manage.py test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf7d610fcc833092396c2f65d03e5a