### PR TITLE
Ensure secure defaults for production

### DIFF
--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -1,15 +1,21 @@
 from pathlib import Path
 import os
+from django.core.exceptions import ImproperlyConfigured
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Obtain SECRET_KEY from env and ensure it is overridden
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'dev-secret-key-change-me')
+if SECRET_KEY in ('dev-secret-key-change-me', 'please-change-this'):
+    raise ImproperlyConfigured('DJANGO_SECRET_KEY must be set to a unique value')
 
 # Read DEBUG from env (default False for deploy)
-DEBUG = os.environ.get('DJANGO_DEBUG', 'True').lower() in ('1', 'true', 'yes')
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('1', 'true', 'yes')
 
 # Allow overriding hosts via env, default to '*'
 ALLOWED_HOSTS = [h.strip() for h in os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(',') if h.strip()]
+if not DEBUG and '*' in ALLOWED_HOSTS:
+    raise ImproperlyConfigured("DJANGO_ALLOWED_HOSTS cannot contain '*' in production")
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
## Summary
- Fail fast if DJANGO_SECRET_KEY uses the example value
- Default DJANGO_DEBUG to False
- Error when ALLOWED_HOSTS allows '*'

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost python backend/manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf817221e48330b9a86eee5c4a7f60