### PR TITLE
Add tests for percent and free shipping coupons

### DIFF
--- a/backend/shop/tests/test_coupon.py
+++ b/backend/shop/tests/test_coupon.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from django.test import TestCase
 
-from shop.models import Category, Product, Coupon
+from shop.models import Category, Product, Coupon, SiteConfig
 from shop.serializers import OrderSerializer
 
 
@@ -42,3 +42,62 @@ class OrderCouponTest(TestCase):
         self.assertEqual(order.coupon_code, "OFF5")
         self.assertEqual(order.total, Decimal("15"))
         self.assertEqual(order.shipping_cost, Decimal("0"))
+
+    def test_percent_coupon(self):
+        cases = [
+            ("PERCENT50", Decimal("50"), Decimal("0"), Decimal("10"), Decimal("10")),
+            ("PERCENT50CAP", Decimal("50"), Decimal("5"), Decimal("5"), Decimal("15")),
+        ]
+        for code, percent, cap, expected_discount, expected_total in cases:
+            with self.subTest(code=code):
+                Coupon.objects.create(
+                    code=code,
+                    type=Coupon.TYPE_PERCENT,
+                    percent=percent,
+                    percent_cap=cap,
+                    active=True,
+                )
+                data = {
+                    "name": "John",
+                    "phone": "123",
+                    "address": "street",
+                    "payment_method": "cash",
+                    "delivery_method": "pickup",
+                    "items": [{"product_id": self.product.id, "quantity": 2}],
+                    "coupon_code": code,
+                }
+                serializer = OrderSerializer(data=data)
+                serializer.is_valid(raise_exception=True)
+                order = serializer.save()
+
+                order.refresh_from_db()
+                self.assertEqual(order.discount_total, expected_discount)
+                self.assertEqual(order.coupon_code, code)
+                self.assertEqual(order.total, expected_total)
+                self.assertEqual(order.shipping_cost, Decimal("0"))
+
+    def test_free_shipping_coupon(self):
+        SiteConfig.objects.create(whatsapp_phone="123", shipping_cost=Decimal("10"))
+        Coupon.objects.create(
+            code="FREESHIP",
+            type=Coupon.TYPE_FREE_SHIPPING,
+            active=True,
+        )
+        data = {
+            "name": "John",
+            "phone": "123",
+            "address": "street",
+            "payment_method": "cash",
+            "delivery_method": "delivery",
+            "items": [{"product_id": self.product.id, "quantity": 2}],
+            "coupon_code": "FREESHIP",
+        }
+        serializer = OrderSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        order = serializer.save()
+
+        order.refresh_from_db()
+        self.assertEqual(order.discount_total, Decimal("0"))
+        self.assertEqual(order.coupon_code, "FREESHIP")
+        self.assertEqual(order.shipping_cost, Decimal("0"))
+        self.assertEqual(order.total, Decimal("20"))


### PR DESCRIPTION
## Summary
- Cover percent-type coupons with and without cap in order serialization tests
- Add free-shipping coupon test ensuring shipping cost waived

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=True python manage.py test shop.tests`

------
https://chatgpt.com/codex/tasks/task_e_68bf84d61cbc8330b083793c2fb8af65