### PR TITLE
Enforce coupon minimum subtotal validation

### DIFF
--- a/backend/shop/tests/test_coupon_validate.py
+++ b/backend/shop/tests/test_coupon_validate.py
@@ -1,0 +1,36 @@
+from decimal import Decimal
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from shop.models import Coupon
+
+
+class CouponValidateAPITests(APITestCase):
+    def setUp(self):
+        self.coupon = Coupon.objects.create(
+            code="OFF20",
+            type=Coupon.TYPE_FIXED,
+            amount=Decimal("20"),
+            min_subtotal=Decimal("100"),
+            active=True,
+        )
+        self.url = reverse("coupon-validate")
+
+    def test_fails_when_subtotal_below_minimum(self):
+        resp = self.client.post(self.url, {"code": "OFF20", "subtotal": "50"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"valid": False, "reason": "min_subtotal"})
+
+    def test_fails_when_subtotal_missing(self):
+        resp = self.client.post(self.url, {"code": "OFF20"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"valid": False, "reason": "min_subtotal"})
+
+    def test_valid_when_subtotal_meets_minimum(self):
+        resp = self.client.post(self.url, {"code": "OFF20", "subtotal": "150"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body.get("valid"))
+        self.assertEqual(body.get("code"), "OFF20")
+

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -69,6 +71,9 @@ class CouponValidateView(APIView):
             c = Coupon.objects.get(code__iexact=code, active=True)
         except Coupon.DoesNotExist:
             return Response({'valid': False}, status=status.HTTP_200_OK)
+        payload_subtotal = Decimal(str(request.data.get('subtotal') or 0))
+        if payload_subtotal < c.min_subtotal:
+            return Response({'valid': False, 'reason': 'min_subtotal'}, status=status.HTTP_200_OK)
         data = CouponSerializer(c).data
         data.update({'valid': True})
         return Response(data)

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -38,11 +38,11 @@ export async function createOrder(payload) {
   return r.json()
 }
 
-export async function validateCoupon(code) {
+export async function validateCoupon(code, subtotal) {
   const r = await fetch(`${API_URL}/coupons/validate/`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code }),
+    body: JSON.stringify({ code, subtotal }),
   })
   if (!r.ok) {
     let err

--- a/frontend/src/pages/Checkout.jsx
+++ b/frontend/src/pages/Checkout.jsx
@@ -169,19 +169,22 @@ export default function Checkout() {
     }
   }
 
-  const applyCoupon = async () => {
-    setCouponMessage(''); setCouponInfo(null); setCouponError(false)
-    if (!coupon.trim()) return
-    try {
-      const info = await validateCoupon(coupon.trim())
-      setCouponInfo(info)
-      if (!info.valid) { setCouponError(true); setCouponMessage('Cupón inválido') }
-      else if (subtotal < Number(info.min_subtotal || 0)) { setCouponError(true); setCouponMessage(`Monto mínimo: ${formatArs(Number(info.min_subtotal || 0))}`) }
-      else { setCouponMessage('Cupón aplicado') }
-    } catch {
-      setCouponError(true); setCouponMessage('No se pudo validar el cupón')
+    const applyCoupon = async () => {
+      setCouponMessage(''); setCouponInfo(null); setCouponError(false)
+      if (!coupon.trim()) return
+      try {
+        const info = await validateCoupon(coupon.trim(), subtotal)
+        if (!info.valid) {
+          setCouponError(true)
+          setCouponMessage(info.reason === 'min_subtotal' ? 'Monto mínimo no alcanzado' : 'Cupón inválido')
+        } else {
+          setCouponInfo(info)
+          setCouponMessage('Cupón aplicado')
+        }
+      } catch {
+        setCouponError(true); setCouponMessage('No se pudo validar el cupón')
+      }
     }
-  }
 
   const copyAlias = async () => {
     try {


### PR DESCRIPTION
## Summary
- Validate coupon usage against provided subtotal and return reason when below minimum
- Send order subtotal when validating coupons from the frontend
- Add integration tests covering coupon validation with various subtotals

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost python manage.py test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf84d3b7608330b5045cedacacfa70