### PR TITLE
Add order throttling and tests

### DIFF
--- a/backend/shop/tests/test_order_throttle.py
+++ b/backend/shop/tests/test_order_throttle.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from shop.models import Category, Product
+
+
+class OrderThrottleTest(APITestCase):
+    def setUp(self):
+        self.category = Category.objects.create(name="Cat", slug="cat")
+        self.product = Product.objects.create(
+            category=self.category,
+            name="Prod",
+            price=Decimal("10.00"),
+            stock=100,
+        )
+        self.url = reverse("order-list")
+        self.data = {
+            "name": "John",
+            "phone": "123",
+            "address": "street",
+            "payment_method": "cash",
+            "delivery_method": "pickup",
+            "items": [{"product_id": self.product.id, "quantity": 1}],
+        }
+
+    def test_orders_throttled_after_limit(self):
+        for i in range(10):
+            response = self.client.post(self.url, self.data, format="json")
+            self.assertNotEqual(
+                response.status_code, 429, f"Request {i} was unexpectedly throttled"
+            )
+
+        response = self.client.post(self.url, self.data, format="json")
+        self.assertEqual(response.status_code, 429)
+

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -55,6 +55,8 @@ class SiteConfigViewSet(viewsets.ViewSet):
 class OrderViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     queryset = Order.objects.all()
     serializer_class = OrderSerializer
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = 'orders'
 
 
 class CouponValidateView(APIView):

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -102,6 +102,7 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_THROTTLE_RATES': {
         'coupon_validate': '5/min',
+        'orders': '10/min',
     },
 }
 


### PR DESCRIPTION
## Summary
- limit order creation using ScopedRateThrottle
- configure REST throttle rates for orders
- add test verifying order endpoint is throttled after 10 requests

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=True python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bf877a085083308e46a3a2a5e630dd