### PR TITLE
Return minimal coupon data

### DIFF
--- a/backend/shop/tests/test_coupon_validate_view.py
+++ b/backend/shop/tests/test_coupon_validate_view.py
@@ -1,0 +1,41 @@
+from decimal import Decimal
+
+from django.test import TestCase
+
+from shop.models import Coupon
+
+
+class CouponValidateViewTest(TestCase):
+    def setUp(self):
+        self.coupon = Coupon.objects.create(
+            code="OFF10",
+            type=Coupon.TYPE_FIXED,
+            amount=Decimal("10.00"),
+            percent=0,
+            percent_cap=0,
+            min_subtotal=Decimal("0"),
+            active=True,
+        )
+
+    def test_response_does_not_expose_internal_fields(self):
+        r = self.client.post(
+            "/api/coupons/validate/",
+            {"code": "OFF10"},
+            content_type="application/json",
+        )
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertTrue(data.get("valid"))
+        expected_keys = {"valid", "type", "amount", "percent", "percent_cap", "min_subtotal"}
+        self.assertEqual(set(data.keys()), expected_keys)
+        self.assertNotIn("active", data)
+        self.assertNotIn("code", data)
+
+    def test_invalid_coupon_response(self):
+        r = self.client.post(
+            "/api/coupons/validate/",
+            {"code": "INVALID"},
+            content_type="application/json",
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"valid": False})

--- a/backend/shop/views.py
+++ b/backend/shop/views.py
@@ -13,7 +13,6 @@ from .serializers import (
     ProductSerializer,
     SiteConfigSerializer,
     OrderSerializer,
-    CouponSerializer,
     AnnouncementSerializer,
 )
 
@@ -69,8 +68,15 @@ class CouponValidateView(APIView):
             c = Coupon.objects.get(code__iexact=code, active=True)
         except Coupon.DoesNotExist:
             return Response({'valid': False}, status=status.HTTP_200_OK)
-        data = CouponSerializer(c).data
-        data.update({'valid': True})
+
+        data = {
+            'valid': True,
+            'type': c.type,
+            'amount': c.amount,
+            'percent': c.percent,
+            'percent_cap': c.percent_cap,
+            'min_subtotal': c.min_subtotal,
+        }
         return Response(data)
 
 

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -49,7 +49,15 @@ export async function validateCoupon(code) {
     try { err = await r.json() } catch { err = { detail: 'No se pudo validar el cupón' } }
     throw new Error(err.detail || JSON.stringify(err))
   }
-  return r.json()
+  const data = await r.json()
+  return {
+    valid: data.valid,
+    type: data.type,
+    amount: data.amount,
+    percent: data.percent,
+    percent_cap: data.percent_cap,
+    min_subtotal: data.min_subtotal,
+  }
 }
 
 export async function getAnnouncements() {

--- a/frontend/src/pages/Checkout.jsx
+++ b/frontend/src/pages/Checkout.jsx
@@ -74,8 +74,8 @@ export default function Checkout() {
 
   const couponSavingsLine = useMemo(() => {
     if (estDiscount <= 0) return null
-    if (couponInfo?.type === 'percent') return { label: `${Number(couponInfo.percent || 0)}% OFF${couponInfo?.name ? ` · ${couponInfo.name}` : ''}`, amount: estDiscount }
-    return { label: `Cupón${couponInfo?.name ? ` · ${couponInfo.name}` : ''}`, amount: estDiscount }
+    if (couponInfo?.type === 'percent') return { label: `${Number(couponInfo.percent || 0)}% OFF`, amount: estDiscount }
+    return { label: 'Cupón', amount: estDiscount }
   }, [estDiscount, couponInfo])
 
   // Fix de textos rotos (mojibake) y placeholders


### PR DESCRIPTION
## Summary
- simplify coupon validation endpoint to return only minimal fields
- adjust frontend API and checkout to handle slim coupon data
- add tests ensuring coupon validation response hides internal fields

## Testing
- `DJANGO_SECRET_KEY=foo DJANGO_DEBUG=1 python manage.py test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf8778b758833081d05e005253e1c9