### PR TITLE
Use QuantityStepper in cart and improve navbar

### DIFF
--- a/frontend/src/components/cart/CartGrouped.jsx
+++ b/frontend/src/components/cart/CartGrouped.jsx
@@ -1,9 +1,11 @@
 import React from 'react'
+import QuantityStepper from '../ui/QuantityStepper.jsx'
 
 // Estructura de carrito agrupado por categoría.
 // Props esperadas:
 // - items: [{ product: {id, name, description, image, price, offer_price, category:{id,name}}, quantity }]
 // - onInc(productId), onDec(productId), onRemove(productId)
+// - onSetQty(productId, quantity)
 // - alertMessages?: array de strings para mostrar debajo del listado
 export default function CartGrouped({
   items = [],
@@ -11,6 +13,7 @@ export default function CartGrouped({
   onDec = () => {},
   onRemove = () => {},
   onClear = () => {},
+  onSetQty = () => {},
   alertMessages = [],
 }) {
   // Agrupar por categoría (name como clave legible; si no hay categoría usa 'Sin categoría')
@@ -90,11 +93,13 @@ export default function CartGrouped({
 
                     {/* Cantidad */}
                     <div className="flex items-center justify-center">
-                      <div className="inline-flex h-9 md:h-10 w-28 items-center justify-between rounded-full bg-orange-600 shadow-sm">
-                        <button aria-label="Disminuir" disabled={quantity <= 1} onClick={() => quantity > 1 && onDec(product.id)} className="h-9 md:h-10 w-9 md:w-10 flex items-center justify-center text-white disabled:opacity-40 disabled:cursor-not-allowed">-</button>
-                        <div className="h-9 md:h-10 w-10 bg-white text-gray-900 flex items-center justify-center font-semibold select-none">{quantity}</div>
-                        <button aria-label="Aumentar" disabled={quantity >= max} onClick={() => quantity < max && onInc(product.id)} className="h-9 md:h-10 w-9 md:w-10 flex items-center justify-center text-white disabled:opacity-40 disabled:cursor-not-allowed">+</button>
-                      </div>
+                      <QuantityStepper
+                        value={quantity}
+                        onDecrement={() => quantity > 1 && onDec(product.id)}
+                        onIncrement={() => quantity < max && onInc(product.id)}
+                        onSet={(v) => onSetQty(product.id, v)}
+                        className="h-9 md:h-10 w-28"
+                      />
                     </div>
                     {isFinite(max) && quantity >= max && (
                       <div className="col-span-full mt-2 rounded-md bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 px-3 py-2 flex items-center gap-2">

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -42,9 +42,9 @@ function Navbar() {
   }, [notifOpen])
 
   return (
-    <nav className="bg-white dark:bg-[#020617] border-b border-gray-200 dark:border-gray-800 shadow-sm sticky top-0 z-20 transition-colors">
+    <nav className="bg-white dark:bg-[#020617] border-b border-gray-200 dark:border-gray-800 shadow-sm fixed top-0 left-0 right-0 z-20 transition-colors">
       <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between relative">
-        <Link to="/" className="flex items-center gap-2">
+        <Link to="/" state={{ resetSearch: true }} className="flex items-center gap-2">
           <img
             src="/logo-icon.png"
             alt="Naranja Autoservicio"
@@ -153,7 +153,7 @@ function App() {
         <div className="flex-1">
           <BrowserRouter>
             <Navbar />
-            <div className="max-w-7xl mx-auto px-4 py-6">
+            <div className="max-w-7xl mx-auto px-4 pt-24 pb-6">
               <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/checkout" element={<Checkout />} />

--- a/frontend/src/pages/Checkout.jsx
+++ b/frontend/src/pages/Checkout.jsx
@@ -228,6 +228,7 @@ export default function Checkout() {
               }}
               onRemove={remove}
               onClear={clear}
+              onSetQty={setQty}
             />
           )}
         </div>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -55,7 +55,10 @@ export default function Home() {
       ordering: orderingMap[sort] || '',
     })
       .then((data) => {
-        setProducts(data.results || [])
+        const results = data.results || []
+        const inStock = results.filter(p => Number(p.stock ?? 0) > 0)
+        const outStock = results.filter(p => Number(p.stock ?? 0) <= 0)
+        setProducts([...inStock, ...outStock])
         setHasNext(Boolean(data.next))
         setHasPrev(Boolean(data.previous))
       })
@@ -73,6 +76,7 @@ export default function Home() {
       setSearch('')
       setQuery('')
       setCategory(null)
+      setSort('relevance')
       setOverlayOpen(false)
       setPage(1)
       // limpiar el state para no repetir al navegar dentro del Home


### PR DESCRIPTION
## Summary
- Use shared QuantityStepper component in cart items
- Reset home search and filter when clicking logo; keep navbar fixed
- Push out-of-stock products to the end of listings

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf8a31a46883309be679d98f9ba8db