### PR TITLE
Enable WhiteNoise for static file serving

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ pytz==2025.2
 ruff==0.12.11
 sqlparse==0.5.3
 typing_extensions==4.15.0
+whitenoise==6.10.0

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
## Summary
- add WhiteNoise dependency
- enable WhiteNoise middleware for production static files

## Testing
- `python manage.py collectstatic --no-input`
- `python manage.py test`
- `curl -I http://127.0.0.1:8000/static/admin/css/base.css`


------
https://chatgpt.com/codex/tasks/task_e_68c1e400b5cc83308c91d750bfb5f53d