### PR TITLE
feat: configure PostgreSQL support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ pathspec==0.12.1
 Pillow==9.5.0
 platformdirs==4.4.0
 pluggy==1.6.0
+psycopg[binary]==3.1.18
 Pygments==2.19.2
 pyright==1.1.404
 pytest==8.4.1

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -65,9 +65,13 @@ TEMPLATES = [
 WSGI_APPLICATION = 'supermercado.wsgi.application'
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "HOST": os.getenv("DJANGO_DB_HOST", "localhost"),
+        "PORT": os.getenv("DJANGO_DB_PORT", "5432"),
+        "NAME": os.getenv("DJANGO_DB_NAME", ""),
+        "USER": os.getenv("DJANGO_DB_USER", ""),
+        "PASSWORD": os.getenv("DJANGO_DB_PASSWORD", ""),
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,29 @@ services:
       DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
       DJANGO_RUN_SEED: ${DJANGO_RUN_SEED:-False}
+      DJANGO_DB_HOST: ${DJANGO_DB_HOST:-postgres}
+      DJANGO_DB_PORT: ${DJANGO_DB_PORT:-5432}
+      DJANGO_DB_NAME: ${DJANGO_DB_NAME:-postgres}
+      DJANGO_DB_USER: ${DJANGO_DB_USER:-postgres}
+      DJANGO_DB_PASSWORD: ${DJANGO_DB_PASSWORD:-postgres}
     volumes:
       - media:/app/media
       - staticfiles:/app/staticfiles
     expose:
       - "8000"
+    depends_on:
+      - postgres
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: ${DJANGO_DB_NAME:-postgres}
+      POSTGRES_USER: ${DJANGO_DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${DJANGO_DB_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
   frontend:
     build:
@@ -33,4 +51,5 @@ services:
 volumes:
   media:
   staticfiles:
+  postgres_data:
 


### PR DESCRIPTION
## Summary
- add psycopg driver for PostgreSQL
- switch Django settings to PostgreSQL with env variables
- add postgres service and env config in docker-compose

## Testing
- `DJANGO_SECRET_KEY=test DJANGO_DEBUG=True DJANGO_ALLOWED_HOSTS=localhost DJANGO_DB_NAME=postgres DJANGO_DB_USER=postgres DJANGO_DB_PASSWORD=postgres python backend/manage.py migrate` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f718804c83308449b511764a26c2