### PR TITLE
Configure S3 storage backend for Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Backend (Django + DRF)
    SEED_ALIAS_OR_CBU=alias.cuenta - Nombre Apellido (Banco) - CUIT 20-00000000-0
    DJANGO_RUN_SEED=False
 
+   # Almacenamiento de archivos en S3 (opcional)
+   DJANGO_DEFAULT_FILE_STORAGE=storages.backends.s3boto3.S3Boto3Storage
+   AWS_ACCESS_KEY_ID=<tu-access-key>
+   AWS_SECRET_ACCESS_KEY=<tu-secret-key>
+   AWS_STORAGE_BUCKET_NAME=<nombre-del-bucket>
+   AWS_S3_REGION_NAME=<region>
+
 3) Migraciones y seed de datos:
 
    cd backend

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,6 +4,7 @@ click==8.2.1
 Django==4.2.10
 django-cors-headers==4.3.1
 django-filter==23.5
+django-storages[boto3]==1.14.6
 djangorestframework==3.14.0
 gunicorn==21.2.0
 iniconfig==2.1.0

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -91,6 +91,16 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
+DEFAULT_FILE_STORAGE = os.getenv(
+    'DJANGO_DEFAULT_FILE_STORAGE',
+    'django.core.files.storage.FileSystemStorage',
+)
+if DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
+    AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
+    AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
+    AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
+    AWS_S3_REGION_NAME = os.getenv('AWS_S3_REGION_NAME')
+
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Asegurar UTF-8 en respuestas


### PR DESCRIPTION
## Summary
- Add `django-storages[boto3]` dependency
- Configure optional AWS S3 file storage via environment variables
- Document S3 environment variables in README

## Testing
- `DJANGO_SECRET_KEY=test-key DJANGO_DEBUG=True python manage.py collectstatic --noinput`
- `DJANGO_SECRET_KEY=test-key DJANGO_DEBUG=True python manage.py test` *(fails: connection refused to PostgreSQL, settings.DATABASES improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f9dd7f208330afd5d5be8b07439a