### PR TITLE
Add Cloudinary storage dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -26,3 +26,5 @@ ruff==0.12.11
 sqlparse==0.5.3
 typing_extensions==4.15.0
 whitenoise==6.10.0
+cloudinary==1.41.0
+django-cloudinary-storage==0.3.0


### PR DESCRIPTION
## Summary
- Include Cloudinary and its Django storage backend in backend requirements.

## Testing
- `pip install -r backend/requirements.txt`
- `pytest` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fb333e9483308d7f020c626f10e9