### PR TITLE
feat: configure cloudinary env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Backend (Django + DRF)
    SEED_ALIAS_OR_CBU=alias.cuenta - Nombre Apellido (Banco) - CUIT 20-00000000-0
    DJANGO_RUN_SEED=False
 
+   CLOUDINARY_CLOUD_NAME=<tu-cloud-name>
+   CLOUDINARY_API_KEY=<tu-api-key>
+   CLOUDINARY_API_SECRET=<tu-api-secret>
+
    # Almacenamiento de archivos en S3 (opcional)
    DJANGO_DEFAULT_FILE_STORAGE=storages.backends.s3boto3.S3Boto3Storage
    AWS_ACCESS_KEY_ID=<tu-access-key>
@@ -93,7 +97,9 @@ Despliegue automático:
 - El flujo `deploy-backend.yml` construye la imagen de Docker y la despliega en
   Railway usando la CLI. Para que funcione, crea un proyecto en Railway,
   vincúlalo con `railway init` y añade el token como secreto `RAILWAY_TOKEN` en
-  GitHub.
+  GitHub. Define también en Railway las variables `CLOUDINARY_CLOUD_NAME`,
+  `CLOUDINARY_API_KEY` y `CLOUDINARY_API_SECRET` para que Django pueda
+  autenticarse contra Cloudinary.
 
 
 Flujo de uso del MVP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
       DJANGO_DB_USER: ${DJANGO_DB_USER:-postgres}
       DJANGO_DB_PASSWORD: ${DJANGO_DB_PASSWORD:-postgres}
       DJANGO_MEDIA_ROOT: ${DJANGO_MEDIA_ROOT:-/app/media}
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
     volumes:
-      - media:/app/media
       - staticfiles:/app/staticfiles
     expose:
       - "8000"
@@ -46,11 +48,9 @@ services:
     ports:
       - "80:80"
     volumes:
-      - media:/media
       - staticfiles:/static
 
 volumes:
-  media:
   staticfiles:
   postgres_data:
 


### PR DESCRIPTION
## Summary
- add Cloudinary env vars to backend service
- drop unused media volume mounts
- document Cloudinary configuration and Railway env vars

## Testing
- `docker compose config` *(fails: command not found)*
- `python - <<'PY'\nimport yaml,sys\nprint('Parsing YAML...')\nwith open('docker-compose.yml') as f:\n    yaml.safe_load(f)\nprint('YAML parsed successfully.')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68c1fb34c3808330894fba4db7409c42