### PR TITLE
Configure Cloudinary storage for Django project

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,8 @@ django-cors-headers==4.3.1
 django-filter==23.5
 django-storages[boto3]==1.14.6
 djangorestframework==3.14.0
+cloudinary==1.41.0
+django-cloudinary-storage==0.3.0
 gunicorn==21.2.0
 iniconfig==2.1.0
 isort==6.0.1

--- a/backend/supermercado/settings.py
+++ b/backend/supermercado/settings.py
@@ -29,6 +29,9 @@ INSTALLED_APPS = [
     'corsheaders',
     'django_filters',
 
+    'cloudinary',
+    'cloudinary_storage',
+
     'shop',
 ]
 
@@ -91,15 +94,14 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 MEDIA_URL = '/media/'
 MEDIA_ROOT = Path(os.getenv('DJANGO_MEDIA_ROOT', BASE_DIR / 'media'))
 
-DEFAULT_FILE_STORAGE = os.getenv(
-    'DJANGO_DEFAULT_FILE_STORAGE',
-    'django.core.files.storage.FileSystemStorage',
-)
-if DEFAULT_FILE_STORAGE == 'storages.backends.s3boto3.S3Boto3Storage':
-    AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
-    AWS_SECRET_ACCESS_KEY = os.getenv('AWS_SECRET_ACCESS_KEY')
-    AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
-    AWS_S3_REGION_NAME = os.getenv('AWS_S3_REGION_NAME')
+CLOUDINARY_STORAGE = {
+    'CLOUD_NAME': os.getenv('CLOUDINARY_CLOUD_NAME'),
+    'API_KEY': os.getenv('CLOUDINARY_API_KEY'),
+    'API_SECRET': os.getenv('CLOUDINARY_API_SECRET'),
+}
+
+DEFAULT_FILE_STORAGE = 'cloudinary_storage.storage.MediaCloudinaryStorage'
+STATICFILES_STORAGE = 'cloudinary_storage.storage.StaticHashedCloudinaryStorage'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 


### PR DESCRIPTION
## Summary
- add Cloudinary and django-cloudinary-storage apps
- configure Cloudinary storage as default and static file storage
- include Cloudinary packages in backend requirements

## Testing
- `DJANGO_SECRET_KEY=testkey DJANGO_DEBUG=1 DJANGO_ALLOWED_HOSTS=localhost python manage.py test` *(fails: connection refused to Postgres, database not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fb3441f88330bb45a9f8dc4e223f